### PR TITLE
Security improvements 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ script:
 after_success:
   - if [ ! -s "$TRAVIS_TAG" ] ; then
       docker tag functions/faas-o6s:latest functions/faas-o6s:$TRAVIS_TAG;
-      docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD;
+      echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
       docker push functions/faas-o6s:$TRAVIS_TAG;
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,18 @@ RUN gofmt -l -d $(find . -type f -name '*.go' -not -path "./vendor/*") && \
   -a -installsuffix cgo -o faas-o6s .
 
 FROM alpine:3.7
-RUN apk --no-cache add ca-certificates
-WORKDIR /root/
+
+RUN addgroup -S app \
+    && adduser -S -g app app \
+    && apk --no-cache add ca-certificates
+
+WORKDIR /home/app
 
 COPY --from=0 /go/src/github.com/openfaas-incubator/faas-o6s/faas-o6s .
+
+RUN chown -R app:app ./
+
+USER app
 
 ENTRYPOINT ["./faas-o6s"]
 CMD ["-logtostderr"]

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -15,10 +15,18 @@ RUN gofmt -l -d $(find . -type f -name '*.go' -not -path "./vendor/*") && \
   -a -installsuffix cgo -o faas-o6s .
 
 FROM alpine:3.6
-RUN apk --no-cache add ca-certificates
-WORKDIR /root/
+
+RUN addgroup -S app \
+    && adduser -S -g app app \
+    && apk --no-cache add ca-certificates
+
+WORKDIR /home/app
 
 COPY --from=0 /go/src/github.com/openfaas-incubator/faas-o6s/faas-o6s    .
+
+RUN chown -R app:app ./
+
+USER app
 
 ENTRYPOINT ["./faas-o6s"]
 CMD ["-logtostderr"]

--- a/artifacts/figlet-armhf.yaml
+++ b/artifacts/figlet-armhf.yaml
@@ -2,6 +2,7 @@ apiVersion: o6s.io/v1alpha1
 kind: Function
 metadata:
   name: figlet
+  namespace: openfaas-fn
 spec:
   name: figlet
   replicas: 2

--- a/artifacts/gofast.yaml
+++ b/artifacts/gofast.yaml
@@ -2,6 +2,7 @@ apiVersion: o6s.io/v1alpha1
 kind: Function
 metadata:
   name: gofast
+  namespace: openfaas-fn
 spec:
   name: gofast
   replicas: 2

--- a/artifacts/nodeinfo.yaml
+++ b/artifacts/nodeinfo.yaml
@@ -2,6 +2,7 @@ apiVersion: o6s.io/v1alpha1
 kind: Function
 metadata:
   name: nodeinfo
+  namespace: openfaas-fn
 spec:
   name: nodeinfo
   replicas: 2

--- a/artifacts/o6s-amd64.yaml
+++ b/artifacts/o6s-amd64.yaml
@@ -43,7 +43,7 @@ spec:
           limits:
             memory: 512Mi
       - name: faas-o6s
-        image: stefanprodan/faas-o6s:0.4.0
+        image: stefanprodan/faas-o6s:0.5.0
         imagePullPolicy: Always
         command:
           - ./faas-o6s

--- a/artifacts/o6s-amd64.yaml
+++ b/artifacts/o6s-amd64.yaml
@@ -43,7 +43,7 @@ spec:
           limits:
             memory: 512Mi
       - name: faas-o6s
-        image: stefanprodan/faas-o6s:0.5.0
+        image: stefanprodan/faas-o6s:0.6.0
         imagePullPolicy: Always
         command:
           - ./faas-o6s

--- a/artifacts/o6s-amd64.yaml
+++ b/artifacts/o6s-amd64.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: faas-o6s
       containers:
       - name: gateway
-        image: functions/gateway:0.7.3
+        image: functions/gateway:0.7.8-rc1
         imagePullPolicy: Always
         env:
         - name: functions_provider_url
@@ -43,7 +43,7 @@ spec:
           limits:
             memory: 512Mi
       - name: faas-o6s
-        image: stefanprodan/faas-o6s:latest-dev
+        image: stefanprodan/faas-o6s:0.4.0
         imagePullPolicy: Always
         command:
           - ./faas-o6s

--- a/artifacts/o6s-rbac.yaml
+++ b/artifacts/o6s-rbac.yaml
@@ -14,13 +14,7 @@ rules:
   resources: ["functions"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]
-  resources: ["services", "events"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["apps", "extensions"]
-  resources: ["deployments"]
+  resources: ["events"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,4 +29,33 @@ subjects:
 - kind: ServiceAccount
   name: faas-o6s
   namespace: openfaas
-
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: faas-o6s-rw
+  namespace: openfaas-fn
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps", "extensions"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: faas-o6s-rw
+  namespace: openfaas-fn
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: faas-o6s-rw
+subjects:
+- kind: ServiceAccount
+  name: faas-o6s
+  namespace: openfaas


### PR DESCRIPTION
This PR adds the following:

* Split RBAC into a cluster role for functions & events and a role for openfaas-fn namespace fix #11 
* Run the controller as non root fix #10
* Fix image pull secret for Kubernetes 1.9 see https://github.com/openfaas/faas-netes/pull/177
* Fix Docker Registry push see https://github.com/openfaas/faas/issues/650

All changes were tested on GKE with `stefanprodan/faas-o6s:0.6.0`.
